### PR TITLE
Updated readme clone link

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 
 
 # Development environment
-   git clone https://github.com/oznzrl/cs_solidity.git --branch main
+   git clone https://github.com/oznzrl/cs_solidty.git --branch main
 
 > • contracts/: Directory for Solidity contracts
 


### PR DESCRIPTION
The clone link had a different link because the name of the repo was misspelled. I suggest changing the repo name or updating the clone link with my issue PR.